### PR TITLE
Use cache logic for recording visualizer

### DIFF
--- a/src/gui/screens/components/waveform/Waveform.h
+++ b/src/gui/screens/components/waveform/Waveform.h
@@ -38,8 +38,13 @@ class Waveform {
     int _samplesPerCachePoint = 1;
 
     void freeCacheMemory();
+    void drawWaveformFrame();
+    void drawWaveformBar(int x, int16_t minSample, int16_t maxSample,
+                         float amplificationGain);
 
-    int _waveformData[MAX_WAVEFORM_POINTS];
+    // Live recording waveform data (min/max pairs)
+    int16_t _liveMinData[MAX_WAVEFORM_POINTS];
+    int16_t _liveMaxData[MAX_WAVEFORM_POINTS];
     int _writeIndex = 0;
 };
 


### PR DESCRIPTION
- Extract common frame/border drawing into drawWaveformFrame() helper
- Create drawWaveformBar() helper for consistent bar rendering
- Update live recording to track min/max pairs instead of single peak
- Both drawWaveform() and drawCachedWaveform() now use same rendering approach
- Apply consistent 3x amplification gain to both visualizers
- Simplify code and reduce duplication

This ensures the live recording visualizer matches the cached waveform rendering style, providing a consistent visual experience.